### PR TITLE
Saving items in formbuilder now works better

### DIFF
--- a/www/formbuilder/js/jquery.formbuilder.js
+++ b/www/formbuilder/js/jquery.formbuilder.js
@@ -748,7 +748,9 @@ function htmlEntities(str) {
 				getFormJSON: function() {
 					openRow = $("[id^='frm-'][id$='-item']");
 					if (openRow.length > 0) {
-						switchMode(openRow,'preview');
+						$(openRow).each(function() {
+							switchMode(this,'preview');
+						});
 					}
 					reSortJSON(ul_obj);
 					return json_data;


### PR DESCRIPTION
Fixed a bug where hitting the save button with several items in edit mode would only save the first item.
