### PR TITLE
fix php upgrade error

### DIFF
--- a/carl_util/basic/html_funcs.php
+++ b/carl_util/basic/html_funcs.php
@@ -13,7 +13,14 @@
  */
 function tagTransform($xhtml, $tag_array)
 {
-	$output = preg_replace("/(<\/?)(\w+)([^>]*>)/e", "'\\1'._tagMap('\\2', \$tag_array ).stripslashes('\\3')", $xhtml);
+	$output = preg_replace_callback(
+		"/(<\/?)(\w+)([^>]*>)/",
+		function ($m) use ($tag_array) {
+			return $m[1] . _tagMap($m[2], $tag_array) . stripslashes($m[3]);
+		},
+		$xhtml
+	);
+
 	return $output;
 }
 


### PR DESCRIPTION
in php 5.5 with preg_replace "The /e modifier is deprecated. Use preg_replace_callback() instead. See the PREG_REPLACE_EVAL documentation for additional information about security risks."