### PR TITLE
Additional styling hooks for publication module

### DIFF
--- a/reason_4.0/lib/core/minisite_templates/modules/publication/module.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/publication/module.php
@@ -2546,8 +2546,12 @@ var $noncanonical_request_keys = array(
 		function show_style_string()
 		{
 			$class_string = ($this->related_mode) ? 'relatedPub' : 'publication';
+			if(empty($this->filters) && empty( $this->current_item_id ))
+				$class_string .= ' homePostsDisplay';
 			if(!empty( $this->current_item_id ) )
 				$class_string .= ' fullPostDisplay';
+			if(!empty($this->filters) && empty( $this->current_item_id ))
+				$class_string .= ' filteredPostsDisplay';
 			echo '<div id="'.$this->style_string.'" class="'.$class_string.'">'."\n";
 		}
 		


### PR DESCRIPTION
Adds two new classes to the publication module wrapper -- "homePostsDisplay" or "filteredPostsDisplay" -- depending on whether you're on the home page or a filtered page (like category archive or search results).