### PR TITLE
Feature/news posts metadata

### DIFF
--- a/reason_4.0/lib/core/content_managers/minisite_page.php3
+++ b/reason_4.0/lib/core/content_managers/minisite_page.php3
@@ -119,7 +119,7 @@ class MinisitePageManager extends parent_childManager
 	
 	function alter_data()
 	{
-		$fields = array('name', 'link_name', 'parent_id', 'parent_info', 'url_fragment', 'custom_page', 'page_type_note', 'content', 'visibility_heading', 'state', 'state_action', 'nav_display', 'indexable','metadata_heading', 'author', 'description', 'keywords', 'administrator_section_heading', 'extra_head_content_structured', 'extra_head_content', 'unique_name');
+		$fields = array('name', 'link_name', 'parent_id', 'parent_info', 'url_fragment', 'custom_page', 'page_type_note', 'content', 'visibility_heading', 'state', 'state_action', 'nav_display', 'indexable','metadata_heading', 'author', 'meta_description', 'keywords', 'administrator_section_heading', 'extra_head_content_structured', 'extra_head_content', 'unique_name');
 		
 		parent::alter_data();
 		$this->_no_tidy[] = 'url_fragment';
@@ -298,7 +298,7 @@ class MinisitePageManager extends parent_childManager
 			
 			$this->set_comments( 'name', form_comment('What should this page be called?') );
 			$this->set_comments( 'author', form_comment('Source or original author of this page') );
-			$this->set_comments( 'description', form_comment('A brief summary of the page. For best results when the page is indexed by search engines, try to not exceed 156 characters.') );
+			$this->set_comments( 'meta_description', form_comment('A brief summary of the page. For best results when the page is indexed by search engines, try to not exceed 156 characters.') );
 			$this->set_comments( 'keywords', form_comment('Comma-separated keywords (for search engines) ie "Dave, Hendler, College, Relations"') );
 			$this->set_comments( 'parent_id', form_comment(''));
 			$this->change_element_type( 'url', 'hidden' );
@@ -310,7 +310,7 @@ class MinisitePageManager extends parent_childManager
 		else
 		{
 			// loop through all elements making them hidden, except for the important link fields
-			$fields = array( 'name', 'url', 'parent_id', 'nav_display', 'description', 'administrator_section_heading', 'unique_name', );
+			$fields = array( 'name', 'url', 'parent_id', 'nav_display', 'meta_description', 'administrator_section_heading', 'unique_name', );
 			foreach($this->get_element_names() as $element_name)
 			{
 				if( !in_array( $element_name, $fields ) )
@@ -326,14 +326,14 @@ class MinisitePageManager extends parent_childManager
 			$this->set_comments( 'url', form_comment('The URL of the external link - should usually begin with http:// unless it is a link to a location within this site') );
 			$this->set_comments( 'name', form_comment('The title of link displayed in your site\'s navigation.') );
 			$this->set_comments( 'parent_id', form_comment('Use this field to choose the link\'s parent page.') );
-			$this->set_comments( 'description', form_comment('A brief description for this link; only displayed if the parent page shows its children.') );
+			$this->set_comments( 'meta_description', form_comment('A brief description for this link; only displayed if the parent page shows its children.') );
 		}
 		
 		// Suggest a limit of 156 characters so that google will display the complete description.
-		$this->change_element_type('description', 'textarea', array('rows' => 4));
+		$this->change_element_type('meta_description', 'textarea', array('rows' => 4));
 		$limiter = new DiscoInputLimiter($this);
-		$limiter->suggest_limit('description', 156);
-		$limiter->auto_show_hide('description', false);
+		$limiter->suggest_limit('meta_description', 156);
+		$limiter->auto_show_hide('meta_description', false);
 		
 		$administrator_fields = array('extra_head_content_structured', 'extra_head_content', 'unique_name');
 		$has_administrator_field = false;

--- a/reason_4.0/lib/core/content_managers/minisite_page.php3
+++ b/reason_4.0/lib/core/content_managers/minisite_page.php3
@@ -119,7 +119,7 @@ class MinisitePageManager extends parent_childManager
 	
 	function alter_data()
 	{
-		$fields = array('name', 'link_name', 'parent_id', 'parent_info', 'url_fragment', 'custom_page', 'page_type_note', 'content', 'visibility_heading', 'state', 'state_action', 'nav_display', 'indexable','metadata_heading', 'author', 'meta_description', 'keywords', 'administrator_section_heading', 'extra_head_content_structured', 'extra_head_content', 'unique_name');
+		$fields = array('name', 'link_name', 'parent_id', 'parent_info', 'url_fragment', 'custom_page', 'page_type_note', 'content', 'visibility_heading', 'state', 'state_action', 'nav_display', 'indexable','metadata_heading', 'author','description', 'keywords', 'administrator_section_heading', 'extra_head_content_structured', 'extra_head_content', 'unique_name');
 		
 		parent::alter_data();
 		$this->_no_tidy[] = 'url_fragment';
@@ -298,7 +298,7 @@ class MinisitePageManager extends parent_childManager
 			
 			$this->set_comments( 'name', form_comment('What should this page be called?') );
 			$this->set_comments( 'author', form_comment('Source or original author of this page') );
-			$this->set_comments( 'meta_description', form_comment('A brief summary of the page. For best results when the page is indexed by search engines, try to not exceed 156 characters.') );
+			$this->set_comments( 'description', form_comment('A brief summary of the page. For best results when the page is indexed by search engines, try to not exceed 156 characters.') );
 			$this->set_comments( 'keywords', form_comment('Comma-separated keywords (for search engines) ie "Dave, Hendler, College, Relations"') );
 			$this->set_comments( 'parent_id', form_comment(''));
 			$this->change_element_type( 'url', 'hidden' );
@@ -310,7 +310,7 @@ class MinisitePageManager extends parent_childManager
 		else
 		{
 			// loop through all elements making them hidden, except for the important link fields
-			$fields = array( 'name', 'url', 'parent_id', 'nav_display', 'meta_description', 'administrator_section_heading', 'unique_name', );
+			$fields = array( 'name', 'url', 'parent_id', 'nav_display', 'description', 'administrator_section_heading', 'unique_name', );
 			foreach($this->get_element_names() as $element_name)
 			{
 				if( !in_array( $element_name, $fields ) )
@@ -326,14 +326,14 @@ class MinisitePageManager extends parent_childManager
 			$this->set_comments( 'url', form_comment('The URL of the external link - should usually begin with http:// unless it is a link to a location within this site') );
 			$this->set_comments( 'name', form_comment('The title of link displayed in your site\'s navigation.') );
 			$this->set_comments( 'parent_id', form_comment('Use this field to choose the link\'s parent page.') );
-			$this->set_comments( 'meta_description', form_comment('A brief description for this link; only displayed if the parent page shows its children.') );
+			$this->set_comments( 'description', form_comment('A brief description for this link; only displayed if the parent page shows its children.') );
 		}
 		
 		// Suggest a limit of 156 characters so that google will display the complete description.
-		$this->change_element_type('meta_description', 'textarea', array('rows' => 4));
+		$this->change_element_type('description', 'textarea', array('rows' => 4));
 		$limiter = new DiscoInputLimiter($this);
-		$limiter->suggest_limit('meta_description', 156);
-		$limiter->auto_show_hide('meta_description', false);
+		$limiter->suggest_limit('description', 156);
+		$limiter->auto_show_hide('description', false);
 		
 		$administrator_fields = array('extra_head_content_structured', 'extra_head_content', 'unique_name');
 		$has_administrator_field = false;

--- a/reason_4.0/lib/core/content_managers/news.php3
+++ b/reason_4.0/lib/core/content_managers/news.php3
@@ -19,16 +19,6 @@
 		var $issues = array();	//[$publicationID][$issueID]=issue_entity;
 		var $news_sections = array();   //[$publicationID][$sectionID]=section_entity;
 
-
-		/*function init_head_items()
-	{
-		parent::init_head_items();
-		if ($this->has_url()) {
-			$this->head_items->add_javascript(WEB_JAVASCRIPT_PATH.'content_managers/page_parent_url.js');
-			$this->head_items->add_javascript(WEB_JAVASCRIPT_PATH.'content_managers/page.js');
-		}
-		$this->head_items->add_stylesheet(REASON_ADMIN_CSS_DIRECTORY.'content_managers/minisite_page.css');
-	}*/
 /////
 // ALTER_DATA & HELPER METHODS
 ////
@@ -46,8 +36,7 @@
 			$this -> set_display_name ('release_title', 'Title');
 			$this -> set_display_name ('datetime', 'Date');
 			$this -> set_display_name ('show_hide', 'Show or Hide?');
-			if($this->_is_element('enable_comment_notification')) 
-			$this -> set_display_name ('enable_comment_notification', 'Email me when new comments are added to this news item:');
+			if($this->_is_element('enable_comment_notification')) $this -> set_display_name ('enable_comment_notification', 'Email me when new comments are added to this news item:');
 		
 			$this -> set_comments ('name', form_comment('A short name that describes the news item. This is for internal use.'));
 			$this -> set_comments ('release_title', form_comment('The actual title of the item -- this is the one that shows up on the public site.'));

--- a/reason_4.0/lib/core/content_managers/news.php3
+++ b/reason_4.0/lib/core/content_managers/news.php3
@@ -6,6 +6,8 @@
 	/**
 	 * Register the content manager with Reason
 	 */
+	include_once( DISCO_INC . 'plugins/input_limiter/input_limiter.php' );
+
 	$GLOBALS[ '_content_manager_class_names' ][ basename( __FILE__) ] = 'news_handler';
 	
 	/**
@@ -17,6 +19,16 @@
 		var $issues = array();	//[$publicationID][$issueID]=issue_entity;
 		var $news_sections = array();   //[$publicationID][$sectionID]=section_entity;
 
+
+		/*function init_head_items()
+	{
+		parent::init_head_items();
+		if ($this->has_url()) {
+			$this->head_items->add_javascript(WEB_JAVASCRIPT_PATH.'content_managers/page_parent_url.js');
+			$this->head_items->add_javascript(WEB_JAVASCRIPT_PATH.'content_managers/page.js');
+		}
+		$this->head_items->add_stylesheet(REASON_ADMIN_CSS_DIRECTORY.'content_managers/minisite_page.css');
+	}*/
 /////
 // ALTER_DATA & HELPER METHODS
 ////
@@ -34,11 +46,14 @@
 			$this -> set_display_name ('release_title', 'Title');
 			$this -> set_display_name ('datetime', 'Date');
 			$this -> set_display_name ('show_hide', 'Show or Hide?');
-			if($this->_is_element('enable_comment_notification')) $this -> set_display_name ('enable_comment_notification', 'Email me when new comments are added to this news item:');
+			if($this->_is_element('enable_comment_notification')) 
+			$this -> set_display_name ('enable_comment_notification', 'Email me when new comments are added to this news item:');
 		
 			$this -> set_comments ('name', form_comment('A short name that describes the news item. This is for internal use.'));
 			$this -> set_comments ('release_title', form_comment('The actual title of the item -- this is the one that shows up on the public site.'));
 			$this -> set_comments ('description', form_comment('A brief summary of the news item; this is what appears on lists of news items'));
+			if($this->_is_element('description')) 
+			$this -> set_display_name ('description', 'Teaser Text');
 			$this -> set_comments ('content', form_comment('The content of the news item.'));
 			$this -> set_comments ('show_hide', form_comment('Hidden items will not show up in the news listings.'));
 
@@ -56,12 +71,23 @@
 # Make this un-hidden again when we have actually IMPLEMENTED comment notification
 			if($this->_is_element('enable_comment_notification')) $this->change_element_type('enable_comment_notification', 'hidden');
 			
+			$this->add_element('metadata_heading', 'comment', array('text' => '<h4>Metadata</h4>
+			<p>These fields provide additional information about the page, but are typically not displayed
+			to site visitors. Description and Keywords are visible to search engines, and can affect how 
+			easily this page can be found by searching.</p>'));
+		
+			$this->change_element_type('meta_description', 'textarea', array('rows' => 4));
+		$limiter = new DiscoInputLimiter($this);
+		$limiter->suggest_limit('meta_description', 156);
+		$limiter->auto_show_hide('meta_description', false);
+		
 			
+		
+
 			//make more sophisticated changes to the content manager
 			$this->alter_commenting_state_field();
 			
 			$this->lokify();
-			
 			
 			$this->make_publication_related_fields();
 			$this->set_values_for_publication_related_fields();
@@ -88,6 +114,7 @@
 			// does the site have categories? if so, lets make it easy to associate a post with categories.
 			$cat_es = new entity_selector($this->get_value('site_id'));
 			$cat_es->description = 'Finding the categories on this site';
+			$cat_es->meta_description = 'Finding the categories on this site';
 			$cat_es->add_type(id_of('category_type'));
 			$categories = $cat_es->run_one();
 			if (!empty($categories))
@@ -102,11 +129,10 @@
 							'author', 
 							'author_description', 
 							'location', 
-							'datetime', 
+							'datetime',
 							'description', 
 							'content',
 							'choose_categories',
-							'keywords', 
 							'names', 
 							'contact_name', 
 							'contact_email', 
@@ -122,6 +148,9 @@
 							'unique_name', 
 							'commenting_state',
 							'enable_comment_notification',
+							'metadata_heading',
+							'meta_description',
+							'keywords',
 							'pubs_heading',);
 							
 			$this -> set_order (array_merge($order, $publication_elements));		
@@ -156,11 +185,21 @@
 			{
 				$wysiwyg_settings_desc['widgets'] = array('strong','em','lists','link','assets');
 			} */
-			
+			$this -> change_element_type ('meta_description', $editor_name , $wysiwyg_settings_desc );
+			$this -> set_comments ('meta_description', form_comment('A brief summary of the page. For best results when the page is indexed by search engines, try to not exceed 156 characters.') );
 			$this -> change_element_type ('description', $editor_name , $wysiwyg_settings_desc );
 			$this -> set_comments ('description', form_comment('A brief summary of the news item; this is what appears on lists of news items'));
+			
+		// Suggest a limit of 156 characters so that google will display the complete description.
+		/*$this->change_element_type('meta_description', 'textarea', array('rows' => 4));
+		$limiter = new DiscoInputLimiter($this);
+		$limiter->suggest_limit('meta_description', 156);
+		$limiter->auto_show_hide('meta_description', false); */
+
+
 			$this->change_element_type( 'content' , $editor_name , $wysiwyg_settings );
 			$this -> set_comments ('content', form_comment('The content of the news item. Please do not include #### at the end of the content'));
+			$this->set_comments( 'keywords', form_comment('Comma-separated keywords (for search engines) ie "Dave, Hendler, College, Relations"') );
 		}
 
 		function make_publication_related_fields()
@@ -168,6 +207,7 @@
 			//find all the publications associated with this site
 			$es = new entity_selector($this->get_value('site_id'));
 			$es->description = 'Finding the publications on this site';
+			$es->meta_description = 'Finding the publications on this site';
 			$es->add_type(id_of('publication_type'));
 			$es->set_order('entity.name ASC');
 			$this->publications = current($es->run());
@@ -212,6 +252,7 @@
 			if($this->publications[$pub_id]->get_value('has_issues') == 'yes')
 			{
 				$es = new entity_selector( $this->get_value('site_id') );
+				$es->meta_description = 'Selecting issues for this publication';
 				$es->description = 'Selecting issues for this publication';
 				$es->add_type( id_of('issue_type') );
 				$es->add_left_relationship( $pub_id, relationship_id_of('issue_to_publication') );
@@ -226,6 +267,7 @@
 			{
 				$es = new entity_selector( $this->get_value('site_id') );
 				$es->description = 'Selecting news sections for this publication';
+				$es->meta_description = 'Selecting news sections for this publication';
 				$es->add_type( id_of('news_section_type'));
 				$es->add_left_relationship( $pub_id, relationship_id_of('news_section_to_publication') );
 				$es->set_order('entity.name ASC');

--- a/reason_4.0/lib/core/content_managers/news.php3
+++ b/reason_4.0/lib/core/content_managers/news.php3
@@ -76,7 +76,7 @@
 			to site visitors. Description and Keywords are visible to search engines, and can affect how 
 			easily this page can be found by searching.</p>'));
 		
-			$this->change_element_type('meta_description', 'textarea', array('rows' => 4));
+			
 		$limiter = new DiscoInputLimiter($this);
 		$limiter->suggest_limit('meta_description', 156);
 		$limiter->auto_show_hide('meta_description', false);
@@ -185,7 +185,7 @@
 			{
 				$wysiwyg_settings_desc['widgets'] = array('strong','em','lists','link','assets');
 			} */
-			$this -> change_element_type ('meta_description', $editor_name , $wysiwyg_settings_desc );
+			//$this -> change_element_type ('meta_description', $editor_name , $wysiwyg_settings_desc );
 			$this -> set_comments ('meta_description', form_comment('A brief summary of the page. For best results when the page is indexed by search engines, try to not exceed 156 characters.') );
 			$this -> change_element_type ('description', $editor_name , $wysiwyg_settings_desc );
 			$this -> set_comments ('description', form_comment('A brief summary of the news item; this is what appears on lists of news items'));

--- a/reason_4.0/lib/core/minisite_templates/modules/publication/module.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/publication/module.php
@@ -1325,6 +1325,8 @@ var $noncanonical_request_keys = array(
 
 	function show_persistent()
 	{
+		$item = new entity($this->current_item_id);
+		
 		if(!empty($this->current_item_id) && $this->request['story_id'] == $this->current_item_id)
 		{
 			$item = new entity($this->current_item_id);

--- a/reason_4.0/lib/core/minisite_templates/modules/publication/module.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/publication/module.php
@@ -1324,9 +1324,7 @@ var $noncanonical_request_keys = array(
 
 
 	function show_persistent()
-	{
-		$item = new entity($this->current_item_id);
-		
+	{		
 		if(!empty($this->current_item_id) && $this->request['story_id'] == $this->current_item_id)
 		{
 			$item = new entity($this->current_item_id);

--- a/reason_4.0/lib/core/scripts/upgrade/4.6_to_4.7/add_Meta_Data_field_to_news.php
+++ b/reason_4.0/lib/core/scripts/upgrade/4.6_to_4.7/add_Meta_Data_field_to_news.php
@@ -1,0 +1,91 @@
+<?php
+
+include_once('reason_header.php');
+reason_include_once('classes/entity_selector.php');
+reason_include_once('classes/upgrade/upgrader_interface.php');
+reason_include_once('classes/field_to_entity_table_class.php');
+
+$GLOBALS['_reason_upgraders']['4.6_to_4.7']['add_Meta_Data_field_to_news'] = 'ReasonUpgrader_47_MetaDataDecription';
+
+class ReasonUpgrader_47_MetaDataDecription implements reasonUpgraderInterface
+{
+	protected $user_id;
+
+  public function ReasonUpgrader_47_MetaDataDecription()
+  {
+    $entity_table_name = 'meta';
+
+    $this->fields = array(
+      'meta_description' => array('db_type' => 'text')
+    );
+
+    $this->updater = new FieldToEntityTable($entity_table_name, $this->fields);
+  }
+
+	public function user_id($user_id = NULL)
+	{
+		if(!empty($user_id))
+			return $this->user_id = $user_id;
+		else
+			return $this->user_id;
+	}
+	/**
+	 * Get the title of the upgrader
+	 * @return string
+	 */
+	public function title()
+	{
+		return 'Adds Meta Data description field.';
+	}
+
+	/**
+	 * Get a description of what this upgrade script will do
+	 *
+	 * @return string HTML description
+	 */
+	public function description()
+	{
+		return '<p>This script adds a new field, meta_description, to sites.</p>';
+	}
+
+  /**
+   * Do a test run of the upgrader
+   * @return string HTML report
+   */
+  public function test()
+  {
+  	if ($this->_test_fields_exist())
+  	{
+  		return '<p>The fields have already been added.';
+  	}
+  	else
+  	{
+  		return '<p>The fields have not yet been added.';
+  	}
+  }
+
+  protected function _test_fields_exist()
+  {
+    return $this->updater->field_exists('meta_description');
+  }
+
+	/**
+	 * Run the upgrader
+	 *
+	 * @return string HTML report
+	 */
+	public function run()
+	{
+		if($this->_test_fields_exist())
+		{
+			return '<p>This updater has already been run.</p>';
+		}
+		else
+		{
+			$this->updater->update_entity_table();
+			ob_start();
+			$this->updater->report();
+			return ob_get_clean();
+		}
+	}
+}

--- a/reason_4.0/www/upgrade.php
+++ b/reason_4.0/www/upgrade.php
@@ -38,6 +38,7 @@ if(!reason_user_has_privs( $reason_user_id, 'upgrade' ) )
 }
 
 $upgrade_steps = array(
+	'4.6_to_4.7' => 'Reason 4.6 to 4.7',
 	'4.5_to_4.6' => 'Reason 4.5 to 4.6',
 	'4.4_to_4.5' => 'Reason 4.4 to 4.5',
 	'4.3_to_4.4' => 'Reason 4.3 to 4.4',


### PR DESCRIPTION
adds news post metadata description as well as changes regular description to teaser to differentiate the two. Allows meta data to be picked up for posts and hides it when a user is taken to a post.