### PR TITLE
fixed bug where default label was not being used in reading ease notifier disco plugin

### DIFF
--- a/disco/plugins/reading_ease_notifier/reading_ease_notifier.php
+++ b/disco/plugins/reading_ease_notifier/reading_ease_notifier.php
@@ -99,7 +99,7 @@
 					$label = REASON_READING_EASE_LABEL;
 				}
 				
-				$formatted_reading_ease_notification .= '<span class="readingEaseLabel">'.REASON_READING_EASE_LABEL.'</span>: <span class="currentReadingEase">' . $score . '</span>';
+				$formatted_reading_ease_notification .= '<span class="readingEaseLabel">'.$label.'</span>: <span class="currentReadingEase">' . $score . '</span>';
 				
 				$formatted_reading_ease_notification .= ' (<span class="currentReadingEaseLabel">' . self::get_ease_label($score) . '</span>)';
 				


### PR DESCRIPTION
Simple bug fix - in instances that use carleton-4.8.1 code the reading ease notifier disco plugin looks kind of funky out of the box because the label is missing. The code is intended to show some default text there that is contained in $label but instead there is a reference to a setting REASON_READING_EASE_LABEL hard-coded that will be missing in most instances and isn't referenced in the upgrade file. The little fix uses $label (which as the value of REASON_READING_EASE_LABEL OR some default text).